### PR TITLE
Fix "Incorrect public key algorithm..." due to mix of EC and RSA in chain

### DIFF
--- a/src/Certificate.js
+++ b/src/Certificate.js
@@ -714,9 +714,9 @@ export default class Certificate
 		//region Importing public key
 		sequence = sequence.then(() => {
 			//region Get information about public key algorithm and default parameters for import
-			const algorithmObject = getAlgorithmByOID(this.subjectPublicKeyInfo.algorithm.algorithmId);
+			const algorithmObject = getAlgorithmByOID(subjectPublicKeyInfo.algorithm.algorithmId);
 			if(("name" in algorithmObject) === false)
-				return Promise.reject(`Unsupported public key algorithm: ${this.subjectPublicKeyInfo.algorithm.algorithmId}`);
+				return Promise.reject(`Unsupported public key algorithm: ${subjectPublicKeyInfo.algorithm.algorithmId}`);
 
 			const algorithm = getAlgorithmParameters(algorithmObject.name, "importkey");
 			if("hash" in algorithm.algorithm)


### PR DESCRIPTION
I just discovered that, by default, SignedData verify doesn't check the whole certificate chain. When I set certChain: true, I got (spurious) verification failures due to these error conditions in `CryptoEngine.importKey`:

```
if(publicKeyInfo.algorithm.algorithmId !== "1.2.840.113549.1.1.1")
    return Promise.reject(`Incorrect public key algorithm: ${publicKeyInfo.algorithm.algorithmId}`);
```

and

```
if(publicKeyInfo.algorithm.algorithmId !== "1.2.840.10045.2.1")
    return Promise.reject(`Incorrect public key algorithm: ${publicKeyInfo.algorithm.algorithmId}`);							
```

The problem is that the wrong `algorithm` is passed into `importKey`. The is probably just an issue in my slightly uncommon case of the cert chain having a mix of EC and RSA public keys. I think this change is needed to make this work properly. 